### PR TITLE
put jid in the right place

### DIFF
--- a/strophe.mam.js
+++ b/strophe.mam.js
@@ -23,7 +23,7 @@ Strophe.addConnectionPlugin('mam', {
         var _p = this._p;
         var attr = {
             type:'set',
-            id:jid
+            to:jid
         };
         options = options || {};
         var mamAttr = {xmlns: Strophe.NS.MAM};


### PR DESCRIPTION
The jid does not belong in `id` which is only used for tracking purposes. I spoke to guys working on the spec and they said they'll add more examples to make this clear