### PR TITLE
Actually do the work of keeping track of a MAM query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strophejs-plugin-mam",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "A strophe.js plugin for Message Archive Management (XEP-0313)",
   "main": "lib/strophe.mam.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "rollup": "^0.45.0"
   },
   "peerDependencies": {
-    "strophe.js": "^1.2.12",
+    "strophe.js": "^1.3.1",
     "strophejs-plugin-rsm": ">=0.0.1"
   }
 }

--- a/src/strophe.mam.js
+++ b/src/strophe.mam.js
@@ -19,6 +19,7 @@ Strophe.addConnectionPlugin('mam', {
         Strophe.addNamespace('MAM', 'urn:xmpp:mam:2');
     },
     query: function (jid, options) {
+        var _c = this._c;
         var _p = this._p;
         var attr = {
             type:'set',
@@ -33,8 +34,7 @@ Strophe.addConnectionPlugin('mam', {
         var iq = $iq(attr).c('query', mamAttr).c('x',{xmlns:'jabber:x:data', type:'submit'});
 
         iq.c('field',{var:'FORM_TYPE', type:'hidden'}).c('value').t(Strophe.NS.MAM).up().up();
-        var i;
-        for (i = 0; i < this._p.length; i++) {
+        for (var i = 0; i < _p.length; i++) {
             var pn = _p[i];
             var p = options[pn];
             delete options[pn];
@@ -50,9 +50,8 @@ Strophe.addConnectionPlugin('mam', {
         delete options.onComplete;
         iq.cnode(new Strophe.RSM(options).toXML());
 
-        var _c = this._c;
         var handler = _c.addHandler(onMessage, Strophe.NS.MAM, 'message', null);
-        return this._c.sendIQ(iq, function(){
+        return _c.sendIQ(iq, function(){
            _c.deleteHandler(handler);
            onComplete.apply(this, arguments);
         });

--- a/src/strophe.mam.js
+++ b/src/strophe.mam.js
@@ -27,7 +27,7 @@ Strophe.addConnectionPlugin('mam', {
         };
         options = options || {};
         var mamAttr = {xmlns: Strophe.NS.MAM};
-        if (!!options.queryid) {
+        if (options.queryid) {
             mamAttr.queryid = options.queryid;
             delete options.queryid;
         } else {
@@ -40,7 +40,7 @@ Strophe.addConnectionPlugin('mam', {
             var pn = _p[i];
             var p = options[pn];
             delete options[pn];
-            if (!!p) {
+            if (p) {
                 iq.c('field',{var:pn}).c('value').t(p).up().up();
             }
         }

--- a/src/strophe.mam.js
+++ b/src/strophe.mam.js
@@ -1,5 +1,6 @@
 /* XEP-0313: Message Archive Management
  * Copyright (C) 2012 Kim Alvefur
+ * Copyright (C) 2018 Emmanuel Gil Peyrot
  *
  * This file is MIT/X11 licensed. Please see the
  * LICENSE.txt file in the source package for more information.

--- a/src/strophe.mam.js
+++ b/src/strophe.mam.js
@@ -57,11 +57,11 @@ Strophe.addConnectionPlugin('mam', {
             // TODO: check the emitter too!
             var result = message.firstChild;
             if (!result || result.namespaceURI !== Strophe.NS.MAM || result.localName !== 'result' || result.getAttributeNS(null, 'queryid') !== queryid)
-                return;
+                return true;
             var id = result.getAttributeNS(null, 'id');
             var forwarded = result.firstChild;
             if (!forwarded || forwarded.namespaceURI !== Strophe.NS.Forward || forwarded.localName !== 'forwarded')
-                return;
+                return true;
             var delay = null;
             var childMessage = null;
             for (var child of forwarded.childNodes.values()) {
@@ -72,6 +72,7 @@ Strophe.addConnectionPlugin('mam', {
             }
             if (childMessage !== null && delay !== null)
                 onMessage(childMessage, delay, id);
+            return true;
         }, Strophe.NS.MAM, 'message', null);
         return _c.sendIQ(iq, function(){
            _c.deleteHandler(handler);

--- a/src/strophe.mam.js
+++ b/src/strophe.mam.js
@@ -26,14 +26,13 @@ Strophe.addConnectionPlugin('mam', {
             to:jid
         };
         options = options || {};
-        var mamAttr = {xmlns: Strophe.NS.MAM};
-        if (options.queryid) {
-            mamAttr.queryid = options.queryid;
+        var queryid = options.queryid;
+        if (queryid) {
             delete options.queryid;
         } else {
-            mamAttr.queryid = _c.getUniqueId();
+            queryid = _c.getUniqueId();
         }
-        var iq = $iq(attr).c('query', mamAttr).c('x',{xmlns:'jabber:x:data', type:'submit'});
+        var iq = $iq(attr).c('query', {xmlns: Strophe.NS.MAM, queryid: queryid}).c('x',{xmlns:'jabber:x:data', type:'submit'});
 
         iq.c('field',{var:'FORM_TYPE', type:'hidden'}).c('value').t(Strophe.NS.MAM).up().up();
         for (var i = 0; i < _p.length; i++) {

--- a/src/strophe.mam.js
+++ b/src/strophe.mam.js
@@ -30,6 +30,8 @@ Strophe.addConnectionPlugin('mam', {
         if (!!options.queryid) {
             mamAttr.queryid = options.queryid;
             delete options.queryid;
+        } else {
+            mamAttr.queryid = _c.getUniqueId();
         }
         var iq = $iq(attr).c('query', mamAttr).c('x',{xmlns:'jabber:x:data', type:'submit'});
 


### PR DESCRIPTION
This library was requiring the user to know everything about a MAM query, instead of doing the work by itself.

With these changes, when the user does a query, this library will send messages (the forwarded kind) plus delay and stanza-id, and handle RSM pagination by itself, making it work as expected.

This is a breaking change, so I incremented the minor version.