### PR TITLE
Adding error call back function with sendIQ()

### DIFF
--- a/src/strophe.mam.js
+++ b/src/strophe.mam.js
@@ -55,6 +55,10 @@ Strophe.addConnectionPlugin('mam', {
         return this._c.sendIQ(iq, function(){
            _c.deleteHandler(handler);
            onComplete.apply(this, arguments);
-        });
+        },
+            function(err){
+                //error callBack function 
+                console.log("Error Response from server:", err);
+            });
     }
 });


### PR DESCRIPTION
this will help to get the error message response by server.
If MAM service is not active in XMPP server, we will get the bellow kind of error message from server:

`
<iq xmlns="jabber:client" from="user02@xmppserver.com" to="user02@xmppserver.com/0F892479AD63271A1558-938994-148287" type="error" xml:lang="en" id="1:sendIQ">
   <query xmlns="urn:xmpp:mam:2">
      <x xmlns="jabber:x:data" type="submit">
         <field var="FORM_TYPE" type="hidden">
            <value>urn:xmpp:mam:2</value>
         </field>
         <field var="with">
            <value>user01@xmppserver.com</value>
         </field>
         <field var="start">
            <value>2017-05-23T00:00:00Z</value>
         </field>
         <field var="end">
            <value>2017-05-26T00:00:00Z</value>
         </field>
      </x>
      <set xmlns="http://jabber.org/protocol/rsm">
         <max />
         <before />
      </set>
   </query>
   <error code="503" type="cancel">
      <service-unavailable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas" />
   </error>
</iq>`